### PR TITLE
Remove background image

### DIFF
--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -3,7 +3,6 @@
 
   #{$page}--header {
     padding: 4rem 0;
-    background-image: url($baseurl + "/assets/images/homepage-v2-hero-bg-mobile.png");
     background-size: auto 100%;
     background-repeat: round;
     margin-bottom: 5rem;
@@ -14,7 +13,6 @@
 
     @include media-breakpoint-up(lg) {
       padding: 8.5rem 0 8rem;
-      background-image: url($baseurl + "/assets/images/homepage-v2-hero-bg.png");
       background-repeat: round;
     }
   }


### PR DESCRIPTION
Based on feedback from a handful of developers, I feel like a simple background is more on-brand for an OSS project.

<img width="1167" alt="Screenshot 2023-03-09 at 3 16 42 PM" src="https://user-images.githubusercontent.com/161938/224145232-bb31ef9f-d8a9-46c8-b5dc-5acd15e2a82f.png">
