### PR TITLE
highlight code with fenl hljs

### DIFF
--- a/_includes/homepage/options-accordion.html
+++ b/_includes/homepage/options-accordion.html
@@ -1,34 +1,33 @@
 <div class="row d-flex d-lg-none justify-content-center">
   <div class="col-md-12" id="options-accordion">
-      {% for tab in site.data.homepage.options.list %}
-      <div class="card">
-        <div class="card-header" id="{{ tab.title | slugify }}-heading">
-          <h5 class="mb-0">
-            <button class="btn btn-link" data-toggle="collapse" data-target="#{{ tab.title | slugify }}-collapse" aria-expanded="{% if forloop.index0 == 0 %}true{% else %}false{% endif %}" aria-controls="{{ tab.title | slugify }}-collapse">
-              {{ tab.title }}
-            </button>
-          </h5>
-        </div>
-    
-        <div id="{{ tab.title | slugify }}-collapse" class="collapse {% if forloop.index0 == 0 %}show{% endif %}" aria-labelledby="{{ tab.title | slugify }}-heading" data-parent="#options-accordion">
-          <div class="card-body">
-            <p>{{ tab.content | newline_to_br }}</p>
-            <code>
-              <pre>{{ tab.code }}</pre>
-            </code>
-            {% if tab.image %}
-            <figure>
-              <img
-                class="img-fluid"
-                src="{{ tab.image | absolute_url }}"
-                alt="{{ tab.title }}"
-              />
-            </figure>
-            {% endif %}
-          </div>
+    {% for tab in site.data.homepage.options.list %}
+    <div class="card">
+      <div class="card-header" id="{{ tab.title | slugify }}-heading">
+        <h5 class="mb-0">
+          <button class="btn btn-link" data-toggle="collapse" data-target="#{{ tab.title | slugify }}-collapse"
+            aria-expanded="{% if forloop.index0 == 0 %}true{% else %}false{% endif %}"
+            aria-controls="{{ tab.title | slugify }}-collapse">
+            {{ tab.title }}
+          </button>
+        </h5>
+      </div>
+
+      <div id="{{ tab.title | slugify }}-collapse" class="collapse {% if forloop.index0 == 0 %}show{% endif %}"
+        aria-labelledby="{{ tab.title | slugify }}-heading" data-parent="#options-accordion">
+        <div class="card-body">
+          <p>{{ tab.content | newline_to_br }}</p>
+          <pre>
+              <code class="language-fenl hljs">{{ tab.code }}</code>
+            </pre>
+          {% if tab.image %}
+          <figure>
+            <img class="img-fluid" src="{{ tab.image | absolute_url }}" alt="{{ tab.title }}" />
+          </figure>
+          {% endif %}
         </div>
       </div>
-      {% endfor %}
     </div>
+    {% endfor %}
   </div>
+</div>
 </div>

--- a/_posts/2022-12-15-the-kaskada-feature-engine-understands-time.md
+++ b/_posts/2022-12-15-the-kaskada-feature-engine-understands-time.md
@@ -71,7 +71,7 @@ Non-pandas python would probably use a more manual strategy, like looping throug
 
 FENL’s syntax for the same would look something like this:
 
-```
+```fenl
 {
    entity_id,
    timestamp,
@@ -81,7 +81,7 @@ FENL’s syntax for the same would look something like this:
 
 While I could argue that FENL’s syntax is somewhat more concise here, it’s more important to point out that, if we wanted both the hourly and the daily event counts, SQL would require two separate CTEs and GROUP BYs (roughly double the amount of SQL code above), whereas FENL can do both in the same code block because FENL understands time, and features are defined independently, like so:
 
-```
+```fenl
 {
    entity_id,
    timestamp,
@@ -146,7 +146,7 @@ Each of these steps would be one CTE, more or less, but of course you could comb
 
 In FENL, we don’t need a date spine or a JOIN, and we can apply the aggregation and the rolling window using functions in the individual feature definition, as in:
 
-```
+```fenl
 {
 entity_id,
 timestamp,


### PR DESCRIPTION

* highlights blog posts with fenl language definition (instead as CSS which is the autodetect) 
* adds fenl highlighting to the code in the landing page's accordeon widget. 