### PR TITLE
[HOTFIX] Fixing spacing in navbar header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
     </button>
 
     <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
-      <ul class="navbar-nav ml-auto mt-2 mt-lg-0">
+      <ul class="navbar-nav ml-auto mt-2 mt-md-0">
         <li class="nav-item nav-item--button">
           <a
             class="btn btn-outline-primary nav-link"

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -6,7 +6,7 @@
     padding-top: 3rem;
     align-items: stretch;
 
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(md) {
       height: auto;
       padding: 0;
       align-items: center;
@@ -36,7 +36,7 @@
       }
     }
 
-    @include media-breakpoint-down(lg) {
+    @include media-breakpoint-down(md) {
       display: inline-flex;
       order: 1;
       margin-bottom: 2rem;
@@ -60,7 +60,7 @@
       }
     }
 
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(md) {
       &:not(:last-of-type) {
         margin-right: 24px;
       }


### PR DESCRIPTION
navbar items were having issues with `margin-bottom` between `992px` and `1200px`, this PR fixes it to keep a consistent navbar layout until the `<= 992px` uses a mobile version.