### PR TITLE
trigger the focus & keyup events in #email field

### DIFF
--- a/_frontend/utils/marketo.js
+++ b/_frontend/utils/marketo.js
@@ -51,17 +51,16 @@ function initializeNewsletter(form) {
   $newsletter.addEventListener("submit", (event) => {
     event.preventDefault();
     const $email = $newsletter.querySelector('input[name="email"]');
+    const $mktoEmail = document.querySelector("#mktoForm_4727 #Email");
 
-    window.theform = form;
     form.setValues({
       Email: $email.value,
     });
 
+    $($mktoEmail).focus();
+    $($mktoEmail).keyup();
     $("#newsletter-modal").modal("show");
 
-    setTimeout(() => {
-      document.querySelector("#mktoForm_4727 #Email").focus();
-    }, 500);
   });
 
   form.onValidate(function onValidate(isValid) {


### PR DESCRIPTION
The marketo form is not showing all the fields until the keyup/focus events are triggered in the `#Email` field. This update trigger both events to ensure the email field is focused but also triggering the `keyup` event to force to show the other fields.