### PR TITLE
[ED-3031] Generate sitemap + redirect insights to blog posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem 'jekyll-seo-tag'
   gem "jekyll-paginate-v2", ">= 3.0"
+  gem 'jekyll-sitemap'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-vite (3.0.4)
       jekyll (>= 3, < 5)
       rackup (~> 0.2)
@@ -86,6 +88,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  -darwin-22
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-21
@@ -99,10 +102,11 @@ DEPENDENCIES
   jekyll-paginate-v2 (>= 3.0)
   jekyll-sass-converter (~> 2.0)
   jekyll-seo-tag
+  jekyll-sitemap
   jekyll-vite
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1.1)
 
 BUNDLED WITH
-   2.4.6
+   2.4.12

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,8 @@ github_username:  kaskada-ai
 collections:
   events:
     output: true
+  redirects:
+    output: true
       #permalink: /events/:path/
 
 sass:

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="refresh" content="0; URL={{ page.to | absolute_url }}" />
+    <title>Document</title>
+  </head>
+  <body>
+    <p>
+      This page has been moved. If you are not redirected within 3 seconds,
+      click <a href="{{ page.to | absolute_url }}">here</a>
+    </p>
+  </body>
+</html>

--- a/_redirects/insights-6-factors-to-consider-when-evaluating-a-new-ml-tool.md
+++ b/_redirects/insights-6-factors-to-consider-when-evaluating-a-new-ml-tool.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/6-factors-to-consider-when-evaluating-a-new-ml-tool
+to: /2022/09/01/6-factors-to-consider-when-evaluating-a-new-ml-tool
+sitemap: false
+---

--- a/_redirects/insights-How-data-science-and-machine-learning-toolsets-benefit-from-kaskada-time-centric-design.md
+++ b/_redirects/insights-How-data-science-and-machine-learning-toolsets-benefit-from-kaskada-time-centric-design.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/How-data-science-and-machine-learning-toolsets-benefit-from-kaskada-time-centric-design
+to: /2022/08/01/How-data-science-and-machine-learning-toolsets-benefit-from-kaskada-time-centric-design
+sitemap: false
+---

--- a/_redirects/insights-discover-how-different-model-contexts-affect-behavior.md
+++ b/_redirects/insights-discover-how-different-model-contexts-affect-behavior.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/discover-how-different-model-contexts-affect-behavior
+to: /2022/12/02/discover-how-different-model-contexts-affect-behavior
+sitemap: false
+---

--- a/_redirects/insights-feature-stores-vs-feature-engines.md
+++ b/_redirects/insights-feature-stores-vs-feature-engines.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/feature-stores-vs-feature-engines
+to: /2022/12/20/feature-stores-vs-feature-engines
+sitemap: false
+---

--- a/_redirects/insights-how-ai-and-ml-are-helping-the-gaming-industry-solve-its-biggest-challenges.md
+++ b/_redirects/insights-how-ai-and-ml-are-helping-the-gaming-industry-solve-its-biggest-challenges.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/how-ai-and-ml-are-helping-the-gaming-industry-solve-its-biggest-challenges
+to: /2022/06/17/how-ai-and-ml-are-helping-the-gaming-industry-solve-its-biggest-challenges
+sitemap: false
+---

--- a/_redirects/insights-hyper-personalization-in-retail-5-ways-to-boost-the-customer-experience.md
+++ b/_redirects/insights-hyper-personalization-in-retail-5-ways-to-boost-the-customer-experience.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/hyper-personalization-in-retail-5-ways-to-boost-the-customer-experience
+to: /2022/07/01/hyper-personalization-in-retail-5-ways-to-boost-the-customer-experience
+sitemap: false
+---

--- a/_redirects/insights-machine-learning-for-data-engineers.md
+++ b/_redirects/insights-machine-learning-for-data-engineers.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/machine-learning-for-data-engineers
+to: /2022/04/15/machine-learning-for-data-engineers
+sitemap: false
+---

--- a/_redirects/insights-the-kaskada-feature-engine-understands-time.md
+++ b/_redirects/insights-the-kaskada-feature-engine-understands-time.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/the-kaskada-feature-engine-understands-time
+to: /2022/12/15/the-kaskada-feature-engine-understands-time
+sitemap: false
+---

--- a/_redirects/insights-why-data-engineers-need-kaskada.md
+++ b/_redirects/insights-why-data-engineers-need-kaskada.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/why-data-engineers-need-kaskada
+to: /2022/07/15/why-data-engineers-need-kaskada
+sitemap: false
+---

--- a/_redirects/insights-why-kaskada-the-three-reasons.md
+++ b/_redirects/insights-why-kaskada-the-three-reasons.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/why-kaskada-the-three-reasons
+to: /2022/10/01/why-kaskada-the-three-reasons
+sitemap: false
+---

--- a/_redirects/insights-why-you-need-a-unified-feature-engine-not-a-unified-compute-model.md
+++ b/_redirects/insights-why-you-need-a-unified-feature-engine-not-a-unified-compute-model.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/why-you-need-a-unified-feature-engine-not-a-unified-compute-model
+to: /2022/05/01/why-you-need-a-unified-feature-engine-not-a-unified-compute-model
+sitemap: false
+---

--- a/_redirects/insights.md
+++ b/_redirects/insights.md
@@ -1,0 +1,6 @@
+---
+layout: redirect
+permalink: /insights/
+to: /blog/
+sitemap: false
+---


### PR DESCRIPTION
old site was having the blog posts using the following URL `/insights/[slug]` now the slugs are based on jekyll default values that are `/[year]/[month]/[date]/[slug]`.

The old URLs were throwing a 404 error since they are not valid anymore.

Jekyll/GH pages doesn't support server redirects, so this PR loads a page that will be redirected to the correct one.