### PR TITLE
Redirect from /workshop to the singup form

### DIFF
--- a/_layouts/redirect_external.html
+++ b/_layouts/redirect_external.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="refresh" content="0; URL={{ page.to }}" />
+    <title>Document</title>
+  </head>
+  <body>
+    <p>
+      This page has been moved. If you are not redirected within 3 seconds,
+      click <a href="{{ page.to }}">here</a>
+    </p>
+  </body>
+</html>

--- a/_layouts/redirect_external.html
+++ b/_layouts/redirect_external.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <p>
-      This page has been moved. If you are not redirected within 3 seconds,
+      This page is a redirect. If you are not redirected within 3 seconds,
       click <a href="{{ page.to }}">here</a>
     </p>
   </body>

--- a/_redirects/workshop.md
+++ b/_redirects/workshop.md
@@ -1,0 +1,6 @@
+---
+layout: redirect_external
+permalink: /workshop/
+to: https://forms.gle/xeSd4ms3WFa2V42T8
+sitemap: false
+---


### PR DESCRIPTION
Turns out we have a way to redirect already, but it assumes the target is a relative path. This modifies that layout to use the "to" value directly and adds the redirect we want for the workshop.